### PR TITLE
Fix stray template loops and add render test

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -212,26 +212,6 @@ TEMPLATE = """
             const brightness = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000;
             td.style.color = brightness > 150 ? '#000' : '#fff';
         });
-        <h2>{{ category }}</h2>
-        <table>
-            <tr>
-            {% for name, url in services.items() %}
-                <td class="{{ STATUS.get(name, {}).get('status', '') }}">
-                    <div class=\"label\">{{ name }}</div>
-                    {% if STATUS[name]['code'] %}
-                        <small>{{ STATUS[name]['code'] }} – {{ STATUS[name]['response_time'] }} ms</small>
-                    {% else %}
-                        <small>No Response</small>
-                    {% endif %}
-                </td>
-                {% if loop.index % 3 == 0 %}
-            </tr><tr>
-                {% endif %}
-            {% endfor %}
-            </tr>
-        </table>
-    {% endfor %}
-    <script>
         function unifySizes() {
             document.querySelectorAll('table').forEach(table => {
                 let maxW = 0;

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,10 @@
+import pytest
+from flask import Flask, render_template_string
+import monitor
+
+app = Flask(__name__)
+
+# Simple test to ensure template compiles without Jinja errors
+@pytest.mark.parametrize('timestamp', ['test'])
+def test_template_renders(timestamp):
+    render_template_string(monitor.TEMPLATE, SERVICES=monitor.SERVICES, STATUS={}, timestamp=timestamp)


### PR DESCRIPTION
## Summary
- clean up duplicate loops in the dashboard template
- add a simple test to ensure the template parses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python monitor.py` *(fails: No module named 'aiohttp')*